### PR TITLE
Misc: Django 5.2 upgrades.

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -68,24 +68,24 @@ jobs:
       matrix:
         python: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         # build LTS version, next version, HEAD
-        django: ["32", "42", "50", "main"]
+        django: ["42", "50", "52", "main"]
         exclude:
           - python: "3.8"
             django: "50"
           - python: "3.8"
+            django: "52"
+          - python: "3.8"
             django: "main"
           - python: "3.9"
             django: "50"
+          - python: "3.9"
+            django: "52"
           - python: "3.9"
             django: "main"
           - python: "3.10"
             django: "main"
           - python: "3.11"
-            django: "32"
-          - python: "3.12"
-            django: "32"
-          - python: "3.12"
-            django: "42"
+            django: "main"
 
     env:
       TOXENV: django${{ matrix.django }}-py${{ matrix.python }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,11 +5,12 @@ repos:
     hooks:
       - id: black
 
-  - repo: https://github.com/charliermarsh/ruff-pre-commit
+  - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: "v0.1.5"
+    rev: "v0.3.0"
     hooks:
       - id: ruff
+        name: ruff check
         args: [--fix, --exit-non-zero-on-fix]
 
   # python static type checking

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,4 +1,6 @@
 line-length = 88
+
+[lint]
 ignore = [
     "D100",  # Missing docstring in public module
     "D101",  # Missing docstring in public class
@@ -19,7 +21,6 @@ ignore = [
     "D411",  # Missing blank line before section
     "D412",  # No blank lines allowed between a section header and its content
     "D416",  # Section name should end with a colon
-    "D417",
     "D417",  # Missing argument description in the docstring
 ]
 select = [
@@ -34,13 +35,13 @@ select = [
     "W",  # pycodestype (warnings)
 ]
 
-[isort]
+[lint.isort]
 combine-as-imports = true
 
-[mccabe]
+[lint.mccabe]
 max-complexity = 8
 
-[per-file-ignores]
+[lint.per-file-ignores]
 "*tests/*" = [
     "D205",  # 1 blank line required between summary line and description
     "D400",  # First line should end with a period

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Django app to manage SAML Identity Providers
 
 ## Version support
 
-This app support Django 3.2+ and Python 3.8+.
+This app supports Django 4.2+ and Python 3.8+.
 
 ## Background
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-simple-saml"
-version = "0.2.0"
+version = "0.3.0"
 description = "Django app for managing multiple SAML Identity Providers."
 license = "MIT"
 authors = ["YunoJuno <code@yunojuno.com>"]
@@ -12,16 +12,14 @@ documentation = "https://github.com/yunojuno/django-simple-saml"
 classifiers = [
     "Environment :: Web Environment",
     "Framework :: Django",
-    "Framework :: Django :: 3.2",
-    "Framework :: Django :: 4.0",
-    "Framework :: Django :: 4.1",
     "Framework :: Django :: 4.2",
     "Framework :: Django :: 5.0",
+    "Framework :: Django :: 5.2",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -30,7 +28,7 @@ packages = [{ include = "simple_saml" }]
 
 [tool.poetry.dependencies]
 python = "^3.8"
-django = "^3.2 | ^4.0 | ^5.0"
+django = "^4.2 | ^5.0 | ^5.2"
 social-auth-app-django = "*"
 python3-saml = "*"
 dj_database_url = { version = "*", optional=true}

--- a/simple_saml/backends.py
+++ b/simple_saml/backends.py
@@ -20,14 +20,14 @@ class SimpleSAMLAuth(BaseSAMLAuth):
             raise ValueError(f"Identity provider {idp_name} is not enabled.")
         return SAMLIdentityProvider(idp_name, **idp.config)
 
-    def get_user_permanent_id(self, attributes: dict) -> str:
-        """Return the permanent user id from the attributes."""
+    def get_user_id(self, details: dict, response: dict) -> str:
+        """Return the permanent user id from the response."""
         try:
-            return super().get_user_permanent_id(attributes=attributes)
+            return super().get_user_id(details, response)
         except KeyError:
             logger.exception(
                 "Error getting user_permanent_id from response. "
-                "Check attributes for more details: %s",
-                attributes,
+                "Check response for more details: %s",
+                response,
             )
             raise

--- a/simple_saml/backends.py
+++ b/simple_saml/backends.py
@@ -20,14 +20,14 @@ class SimpleSAMLAuth(BaseSAMLAuth):
             raise ValueError(f"Identity provider {idp_name} is not enabled.")
         return SAMLIdentityProvider(idp_name, **idp.config)
 
-    def get_user_permanent_id(self, details: dict, response: dict) -> str:
-        """Return the permanent user id from the response."""
+    def get_user_permanent_id(self, attributes: dict) -> str:
+        """Return the permanent user id from the attributes."""
         try:
-            return super().get_user_permanent_id(details, response)
+            return super().get_user_permanent_id(attributes=attributes)
         except KeyError:
             logger.exception(
                 "Error getting user_permanent_id from response. "
-                "Check response for more details: %s",
-                response,
+                "Check attributes for more details: %s",
+                attributes,
             )
             raise

--- a/tox.ini
+++ b/tox.ini
@@ -4,12 +4,10 @@ envlist =
     fmt, lint, mypy,
     django-checks,
     ; https://docs.djangoproject.com/en/5.0/releases/
-    django32-py{38,39,310}
-    django40-py{38,39,310}
-    django41-py{38,39,310,311}
     django42-py{38,39,310,311}
     django50-py{310,311,312}
-    djangomain-py{311,312}
+    django52-py{310,311,312}
+    djangomain-py{312}
 
 [testenv]
 deps =
@@ -17,11 +15,9 @@ deps =
     pytest
     pytest-cov
     pytest-django
-    django32: Django>=3.2,<3.3
-    django40: Django>=4.0,<4.1
-    django41: Django>=4.1,<4.2
     django42: Django>=4.2,<4.3
-    django50: https://github.com/django/django/archive/stable/5.0.x.tar.gz
+    django50: Django>=5.0,<5.1
+    django52: Django>=5.2a1,<5.3
     djangomain: https://github.com/django/django/archive/main.tar.gz
 
 setenv =
@@ -54,7 +50,7 @@ deps =
     ruff
 
 commands =
-    ruff simple_saml
+    ruff check simple_saml
 
 [testenv:mypy]
 description = Python source code type hints (mypy)


### PR DESCRIPTION
# Django 5.2 Support & Modernization

This PR introduces support for Django 5.2 and makes several modernisations to the codebase:

## Changes

- **Django version support**:
  - Added support for Django 5.2
  - Deprecated support for Django versions before 4.2
  - Updated package classifiers accordingly

- **Testing infrastructure**:
  - Updated tox configuration to test with Django 4.2, 5.0, 5.2 and Django main
  - Configured GitHub Actions to test Django main only with Python 3.12

- **Tooling**:
  - Updated ruff command to use modern `ruff check` syntax
  - Updated ruff configuration to use the new structured format with `[lint]` section
  - Updated pre-commit configuration to use latest ruff version

- **Version**:
  - Bumped package version from 0.2.0 to 0.3.0

- **Documentation**:
  - Updated README to reflect new Django version support