### PR TITLE
Add Django 6.0, Python 3.13 support

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -22,10 +22,10 @@ jobs:
       - name: Check out the repository
         uses: actions/checkout@v4
 
-      - name: Set up Python (3.11)
+      - name: Set up Python (3.12)
         uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: Install xmlsec
         run: sudo apt-get install -y libxml2-dev libxmlsec1-dev libxmlsec1-openssl
@@ -48,10 +48,10 @@ jobs:
       - name: Check out the repository
         uses: actions/checkout@v4
 
-      - name: Set up Python (3.11)
+      - name: Set up Python (3.12)
         uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: Install xmlsec
         run: sudo apt-get install -y libxml2-dev libxmlsec1-dev libxmlsec1-openssl
@@ -66,26 +66,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ["3.8", "3.9", "3.10", "3.11", "3.12"]
-        # build LTS version, next version, HEAD
-        django: ["42", "50", "52", "main"]
-        exclude:
-          - python: "3.8"
-            django: "50"
-          - python: "3.8"
-            django: "52"
-          - python: "3.8"
-            django: "main"
-          - python: "3.9"
-            django: "50"
-          - python: "3.9"
-            django: "52"
-          - python: "3.9"
-            django: "main"
-          - python: "3.10"
-            django: "main"
-          - python: "3.11"
-            django: "main"
+        python: ["3.12", "3.13"]
+        django: ["52", "60", "main"]
 
     env:
       TOXENV: django${{ matrix.django }}-py${{ matrix.python }}

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Django app to manage SAML Identity Providers
 
 ## Version support
 
-This app supports Django 4.2+ and Python 3.8+.
+This app supports Python 3.12+ and Django 5.2-6.0.
 
 ## Background
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-simple-saml"
-version = "0.3.0"
+version = "0.4.0"
 description = "Django app for managing multiple SAML Identity Providers."
 license = "MIT"
 authors = ["YunoJuno <code@yunojuno.com>"]
@@ -12,23 +12,19 @@ documentation = "https://github.com/yunojuno/django-simple-saml"
 classifiers = [
     "Environment :: Web Environment",
     "Framework :: Django",
-    "Framework :: Django :: 4.2",
-    "Framework :: Django :: 5.0",
     "Framework :: Django :: 5.2",
+    "Framework :: Django :: 6.0",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
 packages = [{ include = "simple_saml" }]
 
 [tool.poetry.dependencies]
-python = "^3.8"
-django = "^4.2 | ^5.0 | ^5.2"
+python = "^3.12"
+django = ">=5.2,<7.0"
 social-auth-app-django = "*"
 python3-saml = "*"
 dj_database_url = { version = "*", optional=true}

--- a/simple_saml/backends.py
+++ b/simple_saml/backends.py
@@ -10,7 +10,9 @@ logger = logging.getLogger(__name__)
 class SimpleSAMLAuth(BaseSAMLAuth):
     """Subclass of SAMLAuth that stores the IdP info in a model."""
 
-    def get_idp(self, idp_name: str) -> SAMLIdentityProvider:
+    def get_idp(self, idp_name: str | None) -> SAMLIdentityProvider:
+        if idp_name is None:
+            raise ValueError("Identity provider name cannot be None.")
         try:
             idp = IdentityProvider.objects.get(label=idp_name)
         except IdentityProvider.DoesNotExist:
@@ -18,7 +20,7 @@ class SimpleSAMLAuth(BaseSAMLAuth):
         if not idp.is_enabled:
             # TODO: is this a security issue? Should we return a 404 instead?
             raise ValueError(f"Identity provider {idp_name} is not enabled.")
-        return SAMLIdentityProvider(idp_name, **idp.config)
+        return SAMLIdentityProvider(backend=self, name=idp_name, **idp.config)
 
     def get_user_id(self, details: dict, response: dict) -> str:
         """Return the permanent user id from the response."""

--- a/tox.ini
+++ b/tox.ini
@@ -3,11 +3,9 @@ isolated_build = True
 envlist =
     fmt, lint, mypy,
     django-checks,
-    ; https://docs.djangoproject.com/en/5.0/releases/
-    django42-py{38,39,310,311}
-    django50-py{310,311,312}
-    django52-py{310,311,312}
-    djangomain-py{312}
+    django52-py{312,313}
+    django60-py{312,313}
+    djangomain-py{312,313}
 
 [testenv]
 deps =
@@ -15,9 +13,8 @@ deps =
     pytest
     pytest-cov
     pytest-django
-    django42: Django>=4.2,<4.3
-    django50: Django>=5.0,<5.1
-    django52: Django>=5.2a1,<5.3
+    django52: Django>=5.2,<5.3
+    django60: Django>=6.0,<6.1
     djangomain: https://github.com/django/django/archive/main.tar.gz
 
 setenv =


### PR DESCRIPTION
## Summary

This PR upgrades the package to support Django 6.0 and Python 3.13.

## Changes

### Added
  - ✅ Django 6.0 support
  - ✅ Python 3.12, 3.13 support

### Removed
  - ❌ Python 3.9, 3.10, 3.11 support (now requires Python 3.12+)
  - ❌ Django 4.2 and 5.0 support (now supports Django 5.2-6.0)