### PR TITLE
Cursor development environment setup

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,7 +1,0 @@
-{
-  "$schema": "https://www.cursor.com/schemas/environment.schema.json",
-  "build": {
-    "dockerfile": "Dockerfile"
-  },
-  "install": "if [ ! -x .venv/bin/python ]; then python3.12 -m venv .venv; fi && . .venv/bin/activate && python -m pip install --upgrade pip && python -m pip install -r requirements.txt pytest pytest-django"
-}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,35 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This is `django-simple-saml`, a reusable Django library for managing multiple SAML Identity Providers via the database. It is **not** a standalone application — it's a library with a demo app for local testing.
+
+### System dependencies
+
+The `xmlsec` Python package requires native libraries. These must be installed at the OS level before `poetry install` will succeed:
+
+```
+xmlsec1 libxmlsec1-dev libxmlsec1-openssl libxml2-dev pkg-config
+```
+
+### Development commands
+
+All commands use Poetry. See `tox.ini` for the canonical list. Quick reference:
+
+| Task | Command |
+|---|---|
+| Install deps | `poetry install -E localhost` |
+| Tests | `DJANGO_SECRET_KEY="test-key" poetry run pytest --cov=simple_saml --verbose tests/` |
+| Formatting | `poetry run black --check simple_saml` |
+| Linting | `ruff check simple_saml` (ruff is a tox dep, not a Poetry dev dep — install separately or use tox) |
+| Type check | `poetry run mypy simple_saml` |
+| Django checks | `poetry run python manage.py check --fail-level WARNING` |
+| Migration check | `poetry run python manage.py makemigrations --dry-run --check` |
+| Full CI matrix | `poetry run tox` |
+
+### Gotchas
+
+- `ruff` is **not** in `pyproject.toml` dev dependencies — it's only declared in `tox.ini`. Install it separately (`pip install ruff`) or run via `tox -e lint`.
+- Django system checks (`manage.py check`) require the `localhost` extras (`-E localhost`) because the demo app settings reference `django-sslserver`.
+- The `DJANGO_SECRET_KEY` env var must be set when running tests outside of tox (tox sets it automatically).
+- Poetry creates the virtualenv in-project (`.venv/`) per `poetry.toml`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Delete `.cursor/environment.json` and add `AGENTS.md` to fix a `ghcr.io` 403 error and provide dev instructions.

The `.cursor/environment.json` file referenced a Docker image (`ghcr.io/cursor-images/python-3.12:latest`) that returned a 403 Forbidden error, preventing new agents from setting up the development environment. Deleting this file allows snapshot-managed settings to take effect, resolving the issue. `AGENTS.md` provides necessary development environment setup instructions.

---
<p><a href="https://cursor.com/agents/bc-750cb9ad-280a-4cab-8a15-4d3a74861867"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-750cb9ad-280a-4cab-8a15-4d3a74861867"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->